### PR TITLE
Add flask-htmx-tailwind repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [fast-htmx](https://github.com/marty331/fasthtmx) - Fast-HTMX is a demo project of FastAPI an HTMX. The purpose of this project is to illustrate how to create a website with no JavaScript, using only HTML, CSS, and Python.
 - [Flask-Sock HTMX](https://github.com/paluigi/flask-htmx) - Very short example combining HTMX with [Flask-Sock](https://flask-sock.readthedocs.io/en/latest/) for self-updating webpages with minimal dependencies.
 - [django-tailwind-alpine-htmx](https://github.com/AccordBox/django-tailwind-alpine-htmx) A simple Task app built with Django, Tailwind CSS, Alpine.js and HTMX
+- [flask-htmx-tailwind](https://github.com/testdrivenio/flask-htmx-tailwind) - Rapid Prototyping with Flask, htmx, and Tailwind CSS
 
 
 ### Ruby


### PR DESCRIPTION
This PR adds the flask-htmx-tailwind repo (matching the blog post that's already in place).

Thanks for the nice resource!