### PR TITLE
Add HTMX for ⚡️ fiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [fasthx](https://volfpeter.github.io/fasthx/) - HTMX utility with decorator syntax for FastAPI that works with any templating engine (Jinja included).
 - [ludic](https://github.com/paveldedik/ludic) - Lightweight framework for building dynamic HTML pages in pure Python with HTMX.
 - [Bootify.io](https://bootify.io) - Create Spring Boot apps with Thymeleaf and htmx in the browser.
+- [HTMX for ⚡️ fiber](https://github.com/ZEISS/fiber-htmx) - 🔨Write HTML and HTMX applications in pure Go using ⚡️ fiber. And lot more ...
 
 ## Videos
 


### PR DESCRIPTION
Adding another [project for HTMX](https://github.com/ZEISS/fiber-htmx).

This is a middleware for [Fiber](https://docs.gofiber.io/) with a lot of additions like go-based components without go templates, DaisyUI, controller interfaces.