### PR TITLE
docs: add `htmx-lsp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [HTMX for ⚡️ fiber](https://github.com/ZEISS/fiber-htmx) - 🔨Write HTML and HTMX applications in pure Go using ⚡️ fiber. And lot more ...
 - [swift-http-types-htmx](https://github.com/alephao/swift-http-types-htmx) - HTMX extensions for swift-http-types
 - [htmx-debugger](https://github.com/NomadicDaddy/htmx-debugger) - A Chrome extension for debugging and viewing htmx events and attributes
+- [htmx-lsp](https://github.com/ThePrimeagen/htmx-lsp) - Language Server Protocol for Neovim to supercharge HTMX development
 
 ## Videos
 


### PR DESCRIPTION
It's a crime to not include this (especially for neovim users)